### PR TITLE
feat: Apply group theory to semantic group detector

### DIFF
--- a/src/group_theory_action.py
+++ b/src/group_theory_action.py
@@ -1,0 +1,104 @@
+import numpy as np
+
+class GroupAction:
+    """
+    Represents a group of transformations acting on a set of points.
+    """
+    def __init__(self, transformations):
+        """
+        Initializes the GroupAction with a list of transformation functions.
+
+        Args:
+            transformations: A list of functions, where each function represents a group element
+                             (e.g., a rotation, translation). Each function should take a point
+                             (e.g., a numpy array) and return the transformed point.
+        """
+        if not transformations:
+            raise ValueError("Transformations list cannot be empty.")
+        self.transformations = transformations
+
+    def act(self, g, x):
+        """
+        Applies a group element 'g' to a point 'x'.
+
+        Args:
+            g: A transformation function from the group.
+            x: The point (or object) to be transformed.
+
+        Returns:
+            The transformed point.
+        """
+        return g(x)
+
+    def get_orbit(self, x, precision=5):
+        """
+        Calculates the orbit of a point 'x' under the group action.
+        The orbit is the set of all points that can be reached from 'x' by applying
+        all transformations in the group.
+
+        Args:
+            x: The starting point (must be a NumPy array).
+            precision: The decimal precision for rounding to handle floating point inaccuracies.
+
+        Returns:
+            A set of points representing the orbit of 'x'. Using tuples for set hashing.
+        """
+        orbit = set()
+        for g in self.transformations:
+            transformed_point = self.act(g, x)
+            # Round to a certain precision to handle floating point inaccuracies
+            # and convert to tuple for hashability.
+            rounded_point = tuple(np.round(transformed_point, decimals=precision))
+            orbit.add(rounded_point)
+        return orbit
+
+    def get_stabilizer(self, x):
+        """
+        Calculates the stabilizer of a point 'x'.
+        The stabilizer is the subgroup of transformations that leave the point 'x' unchanged.
+
+        Args:
+            x: The point for which to find the stabilizer.
+
+        Returns:
+            A list of transformation functions that form the stabilizer of 'x'.
+        """
+        stabilizer_group = []
+        for g in self.transformations:
+            if np.allclose(self.act(g, x), x):
+                stabilizer_group.append(g)
+        return stabilizer_group
+
+# --- Example Transformation Groups ---
+
+def get_rotation_group_2d(degrees=[90, 180, 270]):
+    """
+    Creates a list of 2D rotation transformations around the origin (0,0).
+    Includes the identity transformation.
+    """
+    transformations = [lambda p: p]  # Identity
+    for angle_deg in degrees:
+        angle_rad = np.radians(angle_deg)
+        # Use a closure to capture the rotation matrix for each angle
+        def make_rotation(rad):
+            rotation_matrix = np.array([
+                [np.cos(rad), -np.sin(rad)],
+                [np.sin(rad),  np.cos(rad)]
+            ])
+            return lambda p: rotation_matrix @ p
+        transformations.append(make_rotation(angle_rad))
+    return transformations
+
+def get_translation_group_2d(translations):
+    """
+    Creates a list of 2D translation transformations.
+    Includes the identity transformation.
+    """
+    transformations = [lambda p: p]  # Identity
+    for t in translations:
+        # Use a closure to capture the translation vector
+        def make_translation(vec):
+            translation_vector = np.array(vec)
+            return lambda p: p + translation_vector
+        transformations.append(make_translation(t))
+    return transformations

--- a/src/semantic_group_detector.py
+++ b/src/semantic_group_detector.py
@@ -2,54 +2,74 @@ import numpy as np
 from collections import Counter
 import cv2
 
+def get_shape_invariant_key(contour, precision=1):
+    """
+    Calculates a shape descriptor key for a contour that is invariant to translation,
+    scale, and rotation. This is achieved using Hu Moments, which are grounded in
+    the principles of group theory (invariance under Euclidean group actions).
+
+    Args:
+        contour: The contour to analyze.
+        precision: The decimal precision for rounding the log-transformed moments.
+
+    Returns:
+        A tuple representing the shape key, or None if the contour is invalid.
+    """
+    moments = cv2.moments(contour)
+    if moments["m00"] == 0:
+        return None
+    
+    # Hu Moments are invariant to translation, scale, and rotation.
+    hu_moments = cv2.HuMoments(moments)
+    
+    # Log-transform to make the moments more comparable and scale-independent.
+    # The absolute value is taken as the sign can change with reflections.
+    log_hu_moments = -np.sign(hu_moments) * np.log10(np.abs(hu_moments))
+    
+    # Round to the specified precision to create a robust key.
+    return tuple(np.round(log_hu_moments, precision).flatten())
+
 def detect_semantic_groups(regions):
     """
-    同形状・類似サイズの対象群を検出し、その数と密度を返す。
+    Detects groups of objects with similar shapes using rotation- and scale-invariant
+    Hu Moments, reflecting a group-theoretic approach to shape analysis.
+    Returns the count of the largest group and its density.
     """
     if not regions or len(regions) < 2:
         return {"group_count": 0.0, "group_density": 0.0}
 
-    # 形状（アスペクト比）とサイズ（面積）でグループ化キーを作成
-    groups = []
-    for r in regions:
-        area = r["w"] * r["h"]
-        if area == 0:
-            continue
-        # 面積はオーダーで丸める（例: 1234 -> 1200）
-        area_order = 10**(np.floor(np.log10(area)) - 1)
-        key = (
-            round(r["w"] / r["h"], 1) if r["h"] > 0 else 0,
-            round(area / area_order) * area_order
-        )
-        groups.append(key)
-    
-    if not groups:
+    # Generate a shape-invariant key for each region based on Hu Moments.
+    keys = [get_shape_invariant_key(r['contour']) for r in regions]
+    valid_keys = [k for k in keys if k is not None]
+
+    if not valid_keys:
         return {"group_count": 0.0, "group_density": 0.0}
 
-    freq = Counter(groups)
-    
-    # 2つ以上でなければグループとはみなさない
+    # Find the most common shape key.
+    freq = Counter(valid_keys)
     dominant_group = freq.most_common(1)[0]
+    
+    # A group must consist of at least 2 objects.
     group_count = dominant_group[1] if dominant_group[1] >= 2 else 0
 
     if group_count == 0:
         return {"group_count": 0.0, "group_density": 0.0}
 
-    # グループの密度を計算
+    # Calculate the density of the dominant group.
     dominant_group_key = dominant_group[0]
-    group_regions = [r for r, k in zip(regions, groups) if k == dominant_group_key]
+    group_regions = [r for r, k in zip(regions, keys) if k == dominant_group_key]
     
-    # グループを囲む最小の円の半径で密度を評価
+    # Evaluate density using the minimum enclosing circle of the group.
     all_points = np.vstack([r['contour'] for r in group_regions])
     (x, y), radius = cv2.minEnclosingCircle(all_points)
     
-    # 密度 = グループの合計面積 / 囲む円の面積
+    # Density = total area of group members / area of the enclosing circle
     group_area = sum(cv2.contourArea(r['contour']) for r in group_regions)
     enclosing_area = np.pi * radius**2
     density = group_area / enclosing_area if enclosing_area > 0 else 0.0
 
-    # 0-1に正規化（グループ数を考慮）
-    normalized_count = min(group_count / 10.0, 1.0) # 10個以上で1.0
+    # Normalize count (e.g., max out at 10 objects for a score of 1.0)
+    normalized_count = min(group_count / 10.0, 1.0)
 
     return {
         "group_count": normalized_count,

--- a/tests/test_group_theory.py
+++ b/tests/test_group_theory.py
@@ -1,0 +1,47 @@
+import unittest
+import numpy as np
+import sys
+import os
+
+# Add the src directory to the Python path to import the module
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
+
+from group_theory_action import GroupAction, get_rotation_group_2d
+
+class TestGroupTheoryAction(unittest.TestCase):
+
+    def test_rotation_orbit(self):
+        """
+        Tests the orbit calculation for a 2D point under a rotation group (C4).
+        """
+        # 1. Define the transformation group (C4: rotations by 0, 90, 180, 270 degrees)
+        c4_rotations = get_rotation_group_2d(degrees=[90, 180, 270])
+        c4_group = GroupAction(c4_rotations)
+
+        # 2. Define a point to act upon
+        point = np.array([1.0, 0.0])
+
+        # 3. Calculate the orbit
+        orbit = c4_group.get_orbit(point)
+
+        # 4. Define the expected orbit
+        # The point (1,0) rotated by 0, 90, 180, 270 degrees
+        expected_orbit = {
+            (1.0, 0.0),    # 0 degrees (identity)
+            (0.0, 1.0),    # 90 degrees
+            (-1.0, 0.0),   # 180 degrees
+            (0.0, -1.0)    # 270 degrees
+        }
+
+        # 5. Assert that the calculated orbit matches the expected one
+        self.assertEqual(orbit, expected_orbit)
+
+    def test_empty_transformations(self):
+        """
+        Tests that initializing GroupAction with an empty list raises an error.
+        """
+        with self.assertRaises(ValueError):
+            GroupAction([])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Closes #3.

This PR resolves Issue #3 by replacing the ad-hoc clustering in `semantic_group_detector.py` with a mathematically rigorous approach based on group theory.

### Changes
- **Refactored `semantic_group_detector.py`**: Now uses Hu Moments to generate shape-invariant keys for grouping. This method is grounded in geometric group theory, as it provides invariance to rotation, translation, and scale.
- **New Module `src/group_theory_action.py`**: Added the `GroupAction` class as proposed in the issue to provide a formal structure for group theory concepts.
- **New Test `tests/test_group_theory.py`**: A unit test was added to verify the correctness of the new group theory module.

These changes align the implementation with the project's core principle of using mathematically-backed methods.
