### PR TITLE
feat(情報理論): Issue #4 の対応 - 情報理論に基づく評価を本格実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ SigmaSenseのアーキテクチャは、二つの異なる知性の協調によ�
   - **該当ファイル**: `sigma_sense.py`, `sigma_local_core.py`
 
 - **情報理論 (Information Theory)**:
-  - **内容**: `compute_entropy`（エントロピー）と`compute_sparsity`（スパース度）を計算し、その結果に基づいて`should_trigger_reconstruction`が意味の再構成が必要かを判断しています。
+  - **内容**: `compute_entropy`（エントロピー）、`mutual_information`（相互情報量）、`kl_divergence`（KLダイバージェンス）といった本格的な情報理論の指標を計算します。`should_trigger_reconstruction`はこれらの指標を利用し、単純な情報量の不足だけでなく、ベクトル間の情報理論的な「距離」が閾値を超えた場合にも、意味の再構成を判断できるようになりました。
   - **該当ファイル**: `information_metrics.py`, `reconstruction_trigger.py`
 
 - **圏論 (Category Theory)**:

--- a/src/information_metrics.py
+++ b/src/information_metrics.py
@@ -1,4 +1,5 @@
 import numpy as np
+from sklearn.metrics import mutual_info_score
 
 def compute_entropy(vector):
     """
@@ -10,6 +11,7 @@ def compute_entropy(vector):
     if total == 0:
         return 0.0
     probs = vec / total
+    # ゼロや負の値をクリップしてlog計算のエラーを防ぐ
     probs = np.clip(probs, 1e-10, 1.0)
     entropy = -np.sum(probs * np.log2(probs))
     return round(float(entropy), 4)
@@ -22,3 +24,52 @@ def compute_sparsity(vector):
     zero_count = np.sum(vec == 0)
     sparsity = zero_count / len(vec)
     return round(float(sparsity), 4)
+
+def mutual_information(x, y, bins=32):
+    """
+    2つの連続値ベクトルの相互情報量を計算する。
+    ベクトルを離散化してから計算する。
+    """
+    x = np.array(x)
+    y = np.array(y)
+    
+    # NaNやinfを有限な値に置き換える
+    x = x[np.isfinite(x)]
+    y = y[np.isfinite(y)]
+
+    if len(x) == 0 or len(y) == 0 or len(x) != len(y):
+        return 0.0
+
+    # 最小値と最大値が同じ場合にbinsを調整
+    min_x, max_x = np.min(x), np.max(x)
+    min_y, max_y = np.min(y), np.max(y)
+
+    x_bins = bins if min_x != max_x else 1
+    y_bins = bins if min_y != max_y else 1
+
+    # 離散化
+    x_digitized = np.digitize(x, np.linspace(min_x, max_x, x_bins))
+    y_digitized = np.digitize(y, np.linspace(min_y, max_y, y_bins))
+    
+    mi = mutual_info_score(x_digitized, y_digitized)
+    return round(float(mi), 4)
+
+def kl_divergence(p, q, epsilon=1e-10):
+    """
+    2つの確率分布ベクトル間のKLダイバージェンスを計算する。
+    D_KL(P || Q)
+    """
+    p = np.asarray(p, dtype=float)
+    q = np.asarray(q, dtype=float)
+
+    # ゼロ除算を避けるために微小な値を加える
+    p = p + epsilon
+    q = q + epsilon
+    
+    # pとqを正規化
+    p = p / np.sum(p)
+    q = q / np.sum(q)
+
+    # KLダイバージェンスの計算
+    divergence = np.sum(p * np.log(p / q))
+    return round(float(divergence), 4)

--- a/src/reconstruction_trigger.py
+++ b/src/reconstruction_trigger.py
@@ -1,7 +1,17 @@
-# 情報理論：エントロピーとスパース度に基づき、意味的断絶を検出する
-def should_trigger_reconstruction(entropy, sparsity, threshold_entropy=2.5, threshold_sparsity=0.4):
+from .information_metrics import compute_entropy, kl_divergence
+
+def should_trigger_reconstruction(vector_p, vector_q=None, threshold_entropy=2.5, threshold_kl=1.0):
     """
     再構成トリガーの発火条件を判定する。
-    情報密度が低い、またはスパース度が高い場合にTrueを返す。
+
+    - ベクトルが1つの場合: 情報量（エントロピー）が閾値を下回った場合にTrueを返す。
+    - ベクトルが2つの場合: 2つのベクトルのKLダイバージェンスが閾値を超えた場合にTrueを返す。
     """
-    return entropy < threshold_entropy or sparsity > threshold_sparsity
+    if vector_q is None:
+        # エントロピーチェック
+        entropy = compute_entropy(vector_p)
+        return entropy < threshold_entropy
+    else:
+        # KLダイバージェンスチェック
+        divergence = kl_divergence(vector_p, vector_q)
+        return divergence > threshold_kl

--- a/tests/test_information_theory.py
+++ b/tests/test_information_theory.py
@@ -1,0 +1,80 @@
+import numpy as np
+import os
+import sys
+
+# Add the project root to the Python path
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from src.information_metrics import compute_entropy, mutual_information, kl_divergence
+from src.reconstruction_trigger import should_trigger_reconstruction
+
+def run_tests():
+    """
+    Runs all information theory related unit tests.
+    """
+    print("--- Starting Information Theory Functions Test ---")
+
+    # --- Test Data ---
+    vec_uniform = np.array([0.25, 0.25, 0.25, 0.25])
+    vec_sparse = np.array([0.9, 0.1, 0.0, 0.0])
+    vec_identical_1 = np.random.rand(100)
+    vec_identical_2 = vec_identical_1.copy()
+    vec_random = np.random.rand(100)
+    dist_p = np.array([0.1, 0.9])
+    dist_q = np.array([0.8, 0.2])
+
+    # --- 1. Entropy Test ---
+    print("\n[1. Entropy Test]")
+    entropy_uniform = compute_entropy(vec_uniform)
+    entropy_sparse = compute_entropy(vec_sparse)
+    print(f"Entropy (Uniform): {entropy_uniform}")
+    print(f"Entropy (Sparse): {entropy_sparse}")
+    assert entropy_uniform > entropy_sparse, "Test failed: Uniform entropy should be greater than sparse entropy."
+    print("OK: Uniform entropy is correctly higher than sparse entropy.")
+
+    # --- 2. Mutual Information Test ---
+    print("\n[2. Mutual Information Test]")
+    mi_identical = mutual_information(vec_identical_1, vec_identical_2)
+    mi_random = mutual_information(vec_identical_1, vec_random)
+    print(f"Mutual Information (Identical): {mi_identical}")
+    print(f"Mutual Information (Random): {mi_random}")
+    assert mi_identical > mi_random, "Test failed: MI for identical vectors should be higher than for random vectors."
+    print("OK: Mutual information for identical vectors is correctly higher.")
+
+    # --- 3. KL Divergence Test ---
+    print("\n[3. KL Divergence Test]")
+    kl_same = kl_divergence(dist_p, dist_p)
+    kl_different = kl_divergence(dist_p, dist_q)
+    print(f"KL Divergence (P || P): {kl_same}")
+    print(f"KL Divergence (P || Q): {kl_different}")
+    assert kl_different > kl_same, "Test failed: KL divergence for different distributions should be greater."
+    print("OK: KL divergence for different distributions is correctly higher.")
+
+    # --- 4. Reconstruction Trigger Test ---
+    print("\n[4. Reconstruction Trigger Test]")
+    # Test Case 4.1: Low entropy trigger
+    low_entropy_vector = [0.99, 0.01, 0, 0, 0, 0, 0, 0, 0, 0]
+    trigger_entropy = should_trigger_reconstruction(low_entropy_vector, threshold_entropy=1.0)
+    print(f"Trigger on low entropy (entropy={compute_entropy(low_entropy_vector)}): {trigger_entropy}")
+    assert trigger_entropy is True, "Test failed: Should trigger for low entropy."
+    print("OK: Triggered correctly on low entropy.")
+
+    # Test Case 4.2: High KL divergence trigger
+    p_vec = [0.1, 0.2, 0.7]
+    q_vec = [0.7, 0.2, 0.1]
+    trigger_kl = should_trigger_reconstruction(p_vec, vector_q=q_vec, threshold_kl=0.5)
+    print(f"Trigger on high KL divergence (KL={kl_divergence(p_vec, q_vec)}): {trigger_kl}")
+    assert trigger_kl is True, "Test failed: Should trigger for high KL divergence."
+    print("OK: Triggered correctly on high KL divergence.")
+
+    # Test Case 4.3: No trigger
+    high_entropy_vector = [0.25, 0.25, 0.25, 0.25]
+    no_trigger_entropy = should_trigger_reconstruction(high_entropy_vector, threshold_entropy=1.0)
+    print(f"No trigger on high entropy (entropy={compute_entropy(high_entropy_vector)}): {not no_trigger_entropy}")
+    assert no_trigger_entropy is False, "Test failed: Should not trigger for high entropy."
+    print("OK: Did not trigger on high entropy as expected.")
+
+    print("\n--- All Information Theory Tests Passed Successfully! ---")
+
+if __name__ == '__main__':
+    run_tests()


### PR DESCRIPTION
Issue #4で指摘された、情報理論の実装が疑似的であるという問題を解決しました。

主な変更点:
- `src/information_metrics.py` に `mutual_information` と `kl_divergence` を追加。
- `src/reconstruction_trigger.py` を更新し、KLダイバージェンスを再構成トリガーに利用できるように拡張。
- 上記の変更を検証するためのテスト `tests/test_information_theory.py` を追加。
- `README.md` を更新し、新しい情報理論の機能について反映。

close #4