### PR TITLE
Refactor sheaf analyzer to use in-memory images

### DIFF
--- a/sigma_image_engines/engine_mobilevit.py
+++ b/sigma_image_engines/engine_mobilevit.py
@@ -28,20 +28,24 @@ class MobileViTEngine:
             print(f"Error: {e}")
             self.model = None
 
-    def _preprocess_image(self, image_path):
-        img = Image.open(image_path).convert('RGB')
+    def _preprocess_image(self, image_path_or_obj):
+        if isinstance(image_path_or_obj, str):
+            img = Image.open(image_path_or_obj).convert('RGB')
+        else:
+            img = image_path_or_obj.convert('RGB')
+
         img = img.resize((self.input_width, self.input_height))
         input_data = np.array(img, dtype=np.float32) / 255.0
         input_data = np.expand_dims(input_data, axis=0)
         return tf.constant(input_data)
 
-    def extract_features(self, image_path):
+    def extract_features(self, image_path_or_obj):
         if not self.model:
-            print(f"MobileViT: Model not loaded for {image_path}. Skipping feature extraction.")
+            print(f"MobileViT: Model not loaded. Skipping feature extraction.")
             return {}
 
         try:
-            input_tensor = self._preprocess_image(image_path)
+            input_tensor = self._preprocess_image(image_path_or_obj)
             
             # 推論関数を直接呼び出します
             output_dict = self.infer(input_tensor)
@@ -56,5 +60,5 @@ class MobileViTEngine:
                 "mobilevit_feature_max": float(np.max(feature_vector)),
             }
         except Exception as e:
-            print(f"Error during MobileViT (SavedModel) inference for {image_path}: {e}")
+            print(f"Error during MobileViT (SavedModel) inference: {e}")
             return {}

--- a/sigma_image_engines/engine_opencv_legacy.py
+++ b/sigma_image_engines/engine_opencv_legacy.py
@@ -14,15 +14,18 @@ class LegacyOpenCVEngine:
         print("Initializing Legacy OpenCV Engine (Selia & Lyra)...")
         self.config = config if config else {}
 
-    def extract_features(self, image_path):
-
+    def extract_features(self, image_path_or_obj):
         """
         Extracts a comprehensive set of features from an image using legacy OpenCV logic.
         """
         try:
-            img = cv2.imread(image_path)
-            if img is None:
-                raise FileNotFoundError(f"画像ファイルが読み込めませんでした: {image_path}")
+            if isinstance(image_path_or_obj, str):
+                img = cv2.imread(image_path_or_obj)
+                if img is None:
+                    raise FileNotFoundError(f"画像ファイルが読み込めませんでした: {image_path_or_obj}")
+            else: # Assume PIL.Image object
+                img = cv2.cvtColor(np.array(image_path_or_obj.convert('RGB')), cv2.COLOR_RGB2BGR)
+
 
             h, w, _ = img.shape
             img_area = h * w

--- a/sigma_image_engines/engine_resnet.py
+++ b/sigma_image_engines/engine_resnet.py
@@ -28,20 +28,24 @@ class ResNetEngine:
             print(f"Error: {e}")
             self.model = None
 
-    def _preprocess_image(self, image_path):
-        img = Image.open(image_path).convert('RGB')
+    def _preprocess_image(self, image_path_or_obj):
+        if isinstance(image_path_or_obj, str):
+            img = Image.open(image_path_or_obj).convert('RGB')
+        else:
+            img = image_path_or_obj.convert('RGB')
+
         img = img.resize((self.input_width, self.input_height))
         input_data = np.array(img, dtype=np.float32) / 255.0
         input_data = np.expand_dims(input_data, axis=0)
         return tf.constant(input_data)
 
-    def extract_features(self, image_path):
+    def extract_features(self, image_path_or_obj):
         if not self.model:
-            print(f"ResNet: Model not loaded for {image_path}. Skipping feature extraction.")
+            print(f"ResNet: Model not loaded. Skipping feature extraction.")
             return {}
 
         try:
-            input_tensor = self._preprocess_image(image_path)
+            input_tensor = self._preprocess_image(image_path_or_obj)
             
             # Call the inference function
             output_dict = self.infer(input_tensor)
@@ -55,5 +59,5 @@ class ResNetEngine:
                 "resnet_v2_50_feature_max": float(np.max(feature_vector)),
             }
         except Exception as e:
-            print(f"Error during ResNet V2 50 (SavedModel) inference for {image_path}: {e}")
+            print(f"Error during ResNet V2 50 (SavedModel) inference: {e}")
             return {}

--- a/src/dimension_generator_local.py
+++ b/src/dimension_generator_local.py
@@ -26,21 +26,19 @@ class DimensionGenerator:
         ]
         print(f"{len(self.engines)} engines loaded.")
 
-    def generate_dimensions(self, image_path):
+    def generate_dimensions(self, image_path_or_obj):
         """
-        Generates a comprehensive dimension object for a given image.
+        Generates a comprehensive dimension object for a given image path or object.
 
         Args:
-            image_path (str): The path to the image file.
+            image_path_or_obj (str or PIL.Image): The path to the image file or a PIL Image object.
 
         Returns:
             dict: A dictionary containing features, provenance, and engine info.
         """
-        if not os.path.exists(image_path):
-            print(f"Error: Image not found at {image_path}")
-            return {"features": {}, "provenance": {}, "engine_info": {}}
-
-        print(f"--- Generating Dimensions for {os.path.basename(image_path)} ---")
+        # Path existence is checked by individual engines if a path is provided.
+        image_name = os.path.basename(image_path_or_obj) if isinstance(image_path_or_obj, str) else "in-memory_image"
+        print(f"--- Generating Dimensions for {image_name} ---")
         
         combined_features = {}
         provenance = {}
@@ -50,7 +48,7 @@ class DimensionGenerator:
             engine_name = engine.__class__.__name__
             try:
                 print(f"Querying {engine_name}")
-                features = engine.extract_features(image_path)
+                features = engine.extract_features(image_path_or_obj)
                 if features:
                     combined_features.update(features)
                     # Record the source engine for each feature

--- a/src/sheaf_analyzer.py
+++ b/src/sheaf_analyzer.py
@@ -28,18 +28,11 @@ class SheafAnalyzer:
         # PILで画像をクロップして渡す。
         cropped_image = self.image.crop((region_rect[0], region_rect[1], region_rect[0] + region_rect[2], region_rect[1] + region_rect[3]))
         
-        # process_experienceはPIL.Imageを受け取れないと仮定し、一時ファイルに保存する
-        # (これはsigma_functor.pyの実装に基づく推測)
-        import tempfile
-        import os
+        # Pass the PIL.Image object directly to process_experience
         vec = None
-        with tempfile.NamedTemporaryFile(suffix=".png", delete=False) as tmp:
-            cropped_image.save(tmp.name, "PNG")
-            # SigmaSenseのベクトル生成メソッドを呼び出す
-            result = self.sigma.process_experience(tmp.name)
-            if result and 'vector' in result:
-                vec = np.array(result['vector'])
-        os.remove(tmp.name)
+        result = self.sigma.process_experience(cropped_image)
+        if result and 'vector' in result:
+            vec = np.array(result['vector'])
         return vec
 
     def assign_local_data(self):

--- a/src/sigma_sense.py
+++ b/src/sigma_sense.py
@@ -209,15 +209,18 @@ class SigmaSense:
         print("--- Ethics Check Completed ---")
         return {"passed": True, "log": ethics_log, "narratives": narratives}
 
-    def process_experience(self, img_path: str):
+    def process_experience(self, image_path_or_obj):
         """
         新しい経験を処理し、自己言及的な思考サイクルを実行する。
+        Args:
+            image_path_or_obj (str or PIL.Image): The path to the image file or a PIL Image object.
         """
-        print(f"\n--- Processing New Experience: {img_path} ---")
+        image_name = os.path.basename(image_path_or_obj) if isinstance(image_path_or_obj, str) else "in-memory_image"
+        print(f"\n--- Processing New Experience: {image_name} ---")
         # =================================================================
         # F0: 知覚 (Perception)
         # =================================================================
-        generation_result = self.generator.generate_dimensions(img_path)
+        generation_result = self.generator.generate_dimensions(image_path_or_obj)
         features_dict = generation_result.get("features", {})
         
         # =================================================================
@@ -277,8 +280,8 @@ class SigmaSense:
             }
 
         current_experience = {
-            "image_path": img_path,
-            "source_image_name": os.path.basename(img_path),
+            "image_path": image_path_or_obj if isinstance(image_path_or_obj, str) else "in-memory_object",
+            "source_image_name": image_name,
             "vector": meaning_vector.tolist(),
             "best_match": {
                 "image_name": best_match_id,


### PR DESCRIPTION
Closes #46. This PR refactors the sheaf analyzer and underlying image engines to process in-memory PIL Image objects directly, removing inefficient temporary file I/O.