### PR TITLE
Fix: Pass config to ToyokawaModel and SigmaReactor in run_psyche_simulation.py (Issue #88)

### DIFF
--- a/scripts/run_psyche_simulation.py
+++ b/scripts/run_psyche_simulation.py
@@ -26,16 +26,22 @@ def print_grand_header():
 if __name__ == '__main__':
     print_grand_header()
 
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    config_dir = os.path.join(project_root, 'config')
+    
+    toyokawa_config_path = os.path.join(config_dir, "toyokawa_model_profile.json")
+    sigma_reactor_config_path = os.path.join(config_dir, "sigma_reactor_profile.json")
+
     # --- Phase 1: Generate Data ---
     logger = PsycheLogger()
     logger.generate_log()
 
     # --- Phase 2: Analyze Data ---
-    model = ToyokawaModel()
+    model = ToyokawaModel(config_path=toyokawa_config_path)
     analysis_results = model.run_analysis()
 
     # --- Phase 3: React to States ---
-    reactor = SigmaReactor()
+    reactor = SigmaReactor(config_path=sigma_reactor_config_path)
     
     if analysis_results:
         print("\n" + "="*70)

--- a/src/sigma_reactor.py
+++ b/src/sigma_reactor.py
@@ -1,4 +1,7 @@
 
+import json
+import os
+
 def print_header(title):
     bar = "="*60
     print(f"\n{bar}\n=== {title.upper()} ===\n{bar}")
@@ -9,29 +12,64 @@ class SigmaReactor:
     group psychological state C(t) calculated by the Toyokawa Model.
     """
 
-    def __init__(self):
+    def __init__(self, config_path=None):
         print_header("Initializing Sigma Reactor")
-        # This data is taken directly from the Ninth Experiment plan
-        self.reaction_map = {
-            "✨ Stable ✨": {
-                "tail": "ゆっくりと左右に振っている",
-                "ears": "穏やかに立っている",
-                "narrative_tempo": "なめらか",
-                "meaning": "全体の語りは調和・共鳴している状態です。"
-            },
-            "💫 Fluctuating 💫": {
-                "tail": "小刻みに揺れている",
-                "ears": "周囲の音を探るように傾いている",
-                "narrative_tempo": "断続的",
-                "meaning": "新たな問いが生まれ、場が探索的になっている状態です。"
-            },
-            "⚠️ Chaotic ⚠️": {
-                "tail": "固く、動きを止めている",
-                "ears": "警戒して伏せられている",
-                "narrative_tempo": "沈黙、あるいは逸脱",
-                "meaning": "語りの流れが分岐・遮断され、緊張が高まっている状態です。"
+        
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        if config_path is None:
+            config_dir = os.path.join(project_root, 'config')
+            self.config_path = os.path.join(config_dir, "sigma_reactor_profile.json")
+        else:
+            self.config_path = config_path
+
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                config_data = json.load(f)
+                self.reaction_map = config_data.get("reaction_map", {})
+        except FileNotFoundError:
+            print(f"Warning: SigmaReactor config file not found at {self.config_path}. Using default reaction map.")
+            self.reaction_map = {
+                "✨ Stable ✨": {
+                    "tail": "ゆっくりと左右に振っている",
+                    "ears": "穏やかに立っている",
+                    "narrative_tempo": "なめらか",
+                    "meaning": "全体の語りは調和・共鳴している状態です。"
+                },
+                "💫 Fluctuating 💫": {
+                    "tail": "小刻みに揺れている",
+                    "ears": "周囲の音を探るように傾いている",
+                    "narrative_tempo": "断続的",
+                    "meaning": "新たな問いが生まれ、場が探索的になっている状態です。"
+                },
+                "⚠️ Chaotic ⚠️": {
+                    "tail": "固く、動きを止めている",
+                    "ears": "警戒して伏せられている",
+                    "narrative_tempo": "沈黙、あるいは逸脱",
+                    "meaning": "語りの流れが分岐・遮断され、緊張が高まっている状態です。"
+                }
             }
-        }
+        except json.JSONDecodeError:
+            print(f"Warning: Could not decode JSON from {self.config_path}. Using default reaction map.")
+            self.reaction_map = {
+                "✨ Stable ✨": {
+                    "tail": "ゆっくりと左右に振っている",
+                    "ears": "穏やかに立っている",
+                    "narrative_tempo": "なめらか",
+                    "meaning": "全体の語りは調和・共鳴している状態です。"
+                },
+                "💫 Fluctuating 💫": {
+                    "tail": "小刻みに揺れている",
+                    "ears": "周囲の音を探るように傾いている",
+                    "narrative_tempo": "断続的",
+                    "meaning": "新たな問いが生まれ、場が探索的になっている状態です。"
+                },
+                "⚠️ Chaotic ⚠️": {
+                    "tail": "固く、動きを止めている",
+                    "ears": "警戒して伏せられている",
+                    "narrative_tempo": "沈黙、あるいは逸脱",
+                    "meaning": "語りの流れが分岐・遮断され、緊張が高まっている状態です。"
+                }
+            }
         print("Reaction patterns for each psychological state have been loaded.")
 
     def generate_reaction(self, state, c_value):


### PR DESCRIPTION
This pull request addresses Issue #88.

The issue reported that `config` was not being passed to components initialized in `run_psyche_simulation.py`. Upon investigation, it was found that `ToyokawaModel` and `SigmaReactor` were being initialized without their respective configuration paths, leading to hardcoded values being used instead of configurable ones.

This fix modifies:
- `src/toyokawa_model.py`:
    - `__init__` method now accepts `config_path`.
    - Loads `toyokawa_model_profile.json` to set `self.weights`.
- `src/sigma_reactor.py`:
    - `__init__` method now accepts `config_path`.
    - Loads `sigma_reactor_profile.json` to set `self.reaction_map`.
- `scripts/run_psyche_simulation.py`:
    - Dynamically constructs paths to `toyokawa_model_profile.json` and `sigma_reactor_profile.json`.
    - Passes these paths to the initializations of `ToyokawaModel` and `SigmaReactor` respectively.

This ensures that `ToyokawaModel` and `SigmaReactor` are properly configured with their intended settings from their profile files.