### PR TITLE
Fix: run_offline_evolution_cycle.pyにおけるDimensionOptimizerのconfigパス解決を修正 (Issue #83)

### DIFF
--- a/scripts/run_offline_evolution_cycle.py
+++ b/scripts/run_offline_evolution_cycle.py
@@ -28,8 +28,11 @@ def reset_config_file(config_path, optimized_path):
     print(f"'{config_path}' has been reset.\nRemoved old '{optimized_path}' if it existed.")
 
 if __name__ == '__main__':
-    CONFIG_PATH = "vector_dimensions_mobile.yaml"
-    OPTIMIZED_CONFIG_PATH = "vector_dimensions_mobile_optimized.yaml"
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    config_dir = os.path.join(project_root, 'config')
+
+    CONFIG_PATH = os.path.join(config_dir, "vector_dimensions_mobile.yaml")
+    OPTIMIZED_CONFIG_PATH = os.path.join(config_dir, "vector_dimensions_mobile_optimized.yaml")
     
     IMG_CIRCLE = "sigma_images/circle_center.jpg"
     IMG_CAT = "sigma_images/cat_01.jpg"


### PR DESCRIPTION
このプルリクエストはIssue #83に対応します。

Issueでは、`run_offline_evolution_cycle.py` で `DimensionOptimizer` の初期化に `config` が渡されていないと報告されていました。調査の結果、`DimensionOptimizer` には `config_path` が渡されていましたが、`scripts/run_offline_evolution_cycle.py` 内で定義されている `CONFIG_PATH` が相対パスであり、スクリプトの実行コンテキストによっては正しく解決されない可能性がありました。

この修正は `scripts/run_offline_evolution_cycle.py` を変更します。
- `if __name__ == '__main__':` ブロック内で定義されている `CONFIG_PATH` と `OPTIMIZED_CONFIG_PATH` を、`config` ディレクトリ内のファイルへの絶対パスとして構築するように修正しました。

これにより、`DimensionOptimizer` が常に正しい設定ファイルをロードできるようになり、`run_offline_evolution_cycle.py` が意図通りに動作することが保証されます。