### PR TITLE
Fix: run_online_integration.pyにおけるoffline_permanentization_log.jsonlのパス解決を修正 (Issue #97)

### DIFF
--- a/scripts/run_online_integration.py
+++ b/scripts/run_online_integration.py
@@ -4,7 +4,9 @@ from gemini_client import GeminiClient # オリエン大賢者をインポート
 
 def run_integration_process():
     """Reads the offline log, has Orien review it, and prepares for permanentization."""
-    log_file = "offline_permanentization_log.jsonl"
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+    log_dir = os.path.join(project_root, 'sigma_logs')
+    log_file = os.path.join(log_dir, "offline_permanentization_log.jsonl")
 
     if not os.path.exists(log_file):
         print(f"✅ 統合対象のログファイル ({log_file}) は見つかりませんでした。全ての学習が完了しています。")


### PR DESCRIPTION
このプルリクエストはIssue #97に対応します。

Issueでは、`offline_permanentization_log.jsonl` が見つからないと報告されていました。調査の結果、`scripts/run_online_integration.py` 内で `log_file` が相対パスとして定義されており、スクリプトの実行コンテキストによっては正しく解決されない可能性がありました。

この修正は `scripts/run_online_integration.py` を変更します。
- `run_integration_process` 関数内で定義されている `log_file` を、`sigma_logs` ディレクトリ内の `offline_permanentization_log.jsonl` への絶対パスとして構築するように修正しました。

これにより、`run_online_integration.py` が常に正しいログファイルを見つけられるようになり、Issue #97が解決されます。