### PR TITLE
Feat: WorldModelのgraph_pathをconfigファイルで設定可能にする (Issue #98)

### DIFF
--- a/src/world_model.py
+++ b/src/world_model.py
@@ -12,20 +12,35 @@ class WorldModel:
       さらには実験を通じて学習した新しい因果関係を、単一のグラフ構造として動的に管理する。
     """
 
-    def __init__(self, graph_path=None):
+    def __init__(self, config_path=None):
         """
         WorldModelを初期化する。
         指定されたパスにグラフファイルが存在すれば読み込み、なければ新しいグラフを作成する。
 
         Args:
-            graph_path (str): グラフを保存・読み込みするためのファイルパス。
+            config_path (str): 設定ファイルへのパス。
         """
-        if graph_path is None:
-            project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-            config_dir = os.path.join(project_root, 'config')
-            self.graph_path = os.path.join(config_dir, "world_model.json")
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        config_dir = os.path.join(project_root, 'config')
+        default_graph_path = os.path.join(config_dir, "world_model.json")
+
+        if config_path is None:
+            self.config_path = os.path.join(config_dir, "world_model_profile.json")
         else:
-            self.graph_path = graph_path
+            self.config_path = config_path
+
+        graph_path_from_config = None
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                profile_config = json.load(f)
+                graph_path_from_config = profile_config.get("graph_path")
+        except (FileNotFoundError, json.JSONDecodeError):
+            print(f"Warning: WorldModel config file not found or invalid at {self.config_path}. Using default graph path.")
+        
+        if graph_path_from_config:
+            self.graph_path = os.path.join(project_root, graph_path_from_config)
+        else:
+            self.graph_path = default_graph_path
             
         self.graph = {
             "nodes": {},


### PR DESCRIPTION
このプルリクエストはIssue #98に対応します。

Issueでは、`WorldModel` の `graph_path` をconfigファイルで設定可能にすることが求められていました。以前は `graph_path` が `WorldModel` の `__init__` メソッドで直接指定されるか、デフォルトのパスがハードコードされていました。

この修正は `src/world_model.py` を変更します。
- `__init__` メソッドが `config_path` 引数を受け入れるようにしました。
- `config_path` から `world_model_profile.json` をロードし、その中から `graph_path` を取得するようにしました。
- プロファイルで `graph_path` が指定されていない場合、または `config_path` が提供されていない場合は、現在のデフォルトのパス (`config/world_model.json`) を使用するようにフォールバックロジックを追加しました。

これにより、`WorldModel` の `graph_path` がconfigファイルを通じて柔軟に設定できるようになり、Issue #98が解決されます。