### PR TITLE
Feat: SheafAnalyzerの許容誤差をconfigファイルで設定可能にする (Issue #105)

### DIFF
--- a/src/sheaf_analyzer.py
+++ b/src/sheaf_analyzer.py
@@ -1,4 +1,7 @@
 
+import json
+import os
+
 import numpy as np
 from PIL import Image
 from . import structure_detector
@@ -8,16 +11,34 @@ class SheafAnalyzer:
     画像に層理論の考え方を適用し、局所的な特徴の整合性を検証するクラス。
     """
 
-    def __init__(self, image_path, sigma_instance):
+    def __init__(self, image_path, sigma_instance, config_path=None):
         """
         Args:
             image_path (str): 分析対象の画像ファイルパス。
             sigma_instance (SigmaSense): 特徴ベクトルを抽出するためのSigmaSenseインスタンス。
+            config_path (str): 設定ファイルへのパス。
         """
         self.image_path = image_path
         self.image = Image.open(image_path).convert('RGB')
         self.sigma = sigma_instance
         self.local_data = {} # region -> feature_vector
+
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        config_dir = os.path.join(project_root, 'config')
+        
+        if config_path is None:
+            self.config_path = os.path.join(config_dir, "sheaf_analyzer_profile.json")
+        else:
+            self.config_path = config_path
+
+        profile_config = {}
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                profile_config = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            print(f"Warning: SheafAnalyzer config file not found or invalid at {self.config_path}. Using default parameters.")
+        
+        self.tolerance = profile_config.get("tolerance", 0.1)
 
     def _get_feature_vector_for_region(self, region_rect):
         """
@@ -59,7 +80,7 @@ class SheafAnalyzer:
             return (x_overlap, y_overlap, x_end - x_overlap, y_end - y_overlap)
         return None
 
-    def check_gluing_condition(self, tolerance=0.1):
+    def check_gluing_condition(self):
         """
         貼り合わせ条件をチェックする。
         全ての領域ペアの交差部分で、特徴ベクトルが整合しているかを確認する。
@@ -91,8 +112,8 @@ class SheafAnalyzer:
                     f2_restricted = f_overlap # Re-use the computed overlap feature
 
                     # ここでの allclose は、異なる計算経路でも同じ結果になるかの確認。
-                    if not np.allclose(f1_restricted, f_overlap, atol=tolerance) or \
-                       not np.allclose(f2_restricted, f_overlap, atol=tolerance):
+                    if not np.allclose(f1_restricted, f_overlap, atol=self.tolerance) or \
+                       not np.allclose(f2_restricted, f_overlap, atol=self.tolerance):
                         print(f"    - Inconsistency found between region {r1} and {r2} at overlap {overlap}")
                         is_consistent = False
         


### PR DESCRIPTION
このプルリクエストはIssue #105に対応します。

Issueでは、`SheafAnalyzer` の許容誤差をconfigファイルで設定可能にすることが求められていました。以前は `tolerance` パラメータが `check_gluing_condition` メソッドの引数としてハードコードされていました。

この修正は `src/sheaf_analyzer.py` を変更します。
- `__init__` メソッドが `config_path` 引数を受け入れるようにしました。
- `config_path` から `sheaf_analyzer_profile.json` をロードし、その中から `tolerance` を取得するようにしました。
- プロファイルで `tolerance` が指定されていない場合、または `config_path` が提供されていない場合は、現在のデフォルト値を使用するようにフォールバックロジックを追加しました。
- `check_gluing_condition` メソッドの引数から `tolerance` のデフォルト値を削除し、`__init__` で設定された `self.tolerance` を使用するように修正しました。

これにより、`SheafAnalyzer` の許容誤差がconfigファイルを通じて柔軟に設定できるようになり、Issue #105が解決されます。