### PR TITLE
Feat: reconstruction_trigger.pyの閾値をconfigファイルで設定可能にする (Issue #93)

### DIFF
--- a/src/reconstruction_trigger.py
+++ b/src/reconstruction_trigger.py
@@ -1,17 +1,43 @@
+import json
+import os
 from .information_metrics import compute_entropy, compute_kl_divergence
 
-def should_trigger_reconstruction(vector_p, vector_q=None, threshold_entropy=2.5, threshold_kl=1.0):
+class ReconstructionTrigger:
     """
-    再構成トリガーの発火条件を判定する。
+    再構成トリガーの発火条件を判定するクラス。
+    """
 
-    - ベクトルが1つの場合: 情報量（エントロピー）が閾値を下回った場合にTrueを返す。
-    - ベクトルが2つの場合: 2つのベクトルのKLダイバージェンスが閾値を超えた場合にTrueを返す。
-    """
-    if vector_q is None:
-        # エントロピーチェック
-        entropy = compute_entropy(vector_p)
-        return entropy < threshold_entropy
-    else:
-        # KLダイバージェンスチェック
-        divergence = compute_kl_divergence(vector_p, vector_q)
-        return divergence > threshold_kl
+    def __init__(self, config_path=None):
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        config_dir = os.path.join(project_root, 'config')
+        
+        if config_path is None:
+            self.config_path = os.path.join(config_dir, "reconstruction_trigger_profile.json")
+        else:
+            self.config_path = config_path
+
+        profile_config = {}
+        try:
+            with open(self.config_path, 'r', encoding='utf-8') as f:
+                profile_config = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            print(f"Warning: ReconstructionTrigger config file not found or invalid at {self.config_path}. Using default parameters.")
+        
+        self.threshold_entropy = profile_config.get("threshold_entropy", 2.5)
+        self.threshold_kl = profile_config.get("threshold_kl", 1.0)
+
+    def should_trigger_reconstruction(self, vector_p, vector_q=None):
+        """
+        再構成トリガーの発火条件を判定する。
+
+        - ベクトルが1つの場合: 情報量（エントロピー）が閾値を下回った場合にTrueを返す。
+        - ベクトルが2つの場合: 2つのベクトルのKLダイバージェンスが閾値を超えた場合にTrueを返す。
+        """
+        if vector_q is None:
+            # エントロピーチェック
+            entropy = compute_entropy(vector_p)
+            return entropy < self.threshold_entropy
+        else:
+            # KLダイバージェンスチェック
+            divergence = compute_kl_divergence(vector_p, vector_q)
+            return divergence > self.threshold_kl


### PR DESCRIPTION
このプルリクエストはIssue #93に対応します。

Issueでは、`reconstruction_trigger.py` の閾値をconfigファイルで設定可能にすることが求められていました。以前は `should_trigger_reconstruction` 関数内で `threshold_entropy` と `threshold_kl` がハードコードされていました。

この修正は `src/reconstruction_trigger.py` を変更します。
- `reconstruction_trigger.py` をクラス `ReconstructionTrigger` に変換しました。
- `__init__` メソッドが `config_path` 引数を受け入れるようにしました。
- `config_path` から `reconstruction_trigger_profile.json` をロードし、その中から `threshold_entropy` と `threshold_kl` を取得するようにしました。
- プロファイルでこれらのパラメータが指定されていない場合、または `config_path` が提供されていない場合は、現在のデフォルト値を使用するようにフォールバックロジックを追加しました。
- `should_trigger_reconstruction` 関数を `ReconstructionTrigger` クラスのメソッドに変換し、引数からデフォルト値を削除し、`__init__` で設定された `self.threshold_entropy` と `self.threshold_kl` を使用するように修正しました。

これにより、`ReconstructionTrigger` の閾値がconfigファイルを通じて柔軟に設定できるようになり、Issue #93が解決されます。