### PR TITLE
feat: 意味的自己相関場スコアの実装

### DIFF
--- a/src/information_metrics.py
+++ b/src/information_metrics.py
@@ -151,3 +151,36 @@ def compute_wasserstein_similarity(vec_a, vec_b, num_bins=10):
     
     # 距離を類似度に変換
     return 1.0 / (1.0 + dist)
+
+def compute_self_correlation_score(vector):
+    """
+    ベクトルの前半と後半のピアソン相関係数を計算する。
+    これにより、ベクトルの内部的な構造的連続性・安定性を評価する。
+    """
+    vec = np.asarray(vector, dtype=float)
+    n = len(vec)
+    if n < 2:
+        return 0.0  # 2要素未満のベクトルでは相関は計算できない
+
+    # ベクトルを前半と後半に分割
+    mid = n // 2
+    v1 = vec[:mid]
+    v2 = vec[n-mid:] # 後半を末尾から取得することで、奇数長の場合に中央要素を自然に無視
+
+    # 平均を計算
+    mean1, mean2 = np.mean(v1), np.mean(v2)
+
+    # 標準偏差を計算
+    std1, std2 = np.std(v1), np.std(v2)
+
+    # 標準偏差がゼロの場合、相関は計算できない（またはゼロとする）
+    if std1 == 0 or std2 == 0:
+        return 0.0
+
+    # 共分散を計算
+    covariance = np.mean((v1 - mean1) * (v2 - mean2))
+
+    # ピアソン相関係数を計算
+    correlation = covariance / (std1 * std2)
+    
+    return round(float(correlation), 4)

--- a/src/sigma_sense.py
+++ b/src/sigma_sense.py
@@ -4,7 +4,7 @@ import numpy as np
 import os
 import json
 from .dimension_loader import DimensionLoader
-from .information_metrics import compute_kl_similarity, compute_wasserstein_similarity
+from .information_metrics import compute_kl_similarity, compute_wasserstein_similarity, compute_self_correlation_score
 
 # --- 旧来のコンポーネント ---
 from .dimension_generator_local import DimensionGenerator
@@ -203,6 +203,9 @@ class SigmaSense:
 
         best_match_id, score, best_match_vector = self._find_best_match(meaning_vector, metric='cosine', num_bins=10)
 
+        # 意味ベクトルの自己相関場スコアを計算
+        self_correlation = compute_self_correlation_score(meaning_vector)
+
         # =================================================================
         # F2: 経験の記録 (Memory Consolidation)
         # =================================================================
@@ -242,7 +245,10 @@ class SigmaSense:
                 "score": float(score) if score is not None else 0.0,
             },
             "fusion_data": {"logical_terms": logical_terms_with_types},
-            "auxiliary_analysis": {"psyche_state": self.psyche_modulator.get_current_state()}
+            "auxiliary_analysis": {
+                "psyche_state": self.psyche_modulator.get_current_state(),
+                "self_correlation_score": self_correlation
+            }
         }
         
         memory_entry = self.memory_graph.add_experience(current_experience)

--- a/tests/test_information_theory.py
+++ b/tests/test_information_theory.py
@@ -7,7 +7,7 @@ import collections
 # Add the src directory to the Python path to import the module
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '../src')))
 
-from information_metrics import compute_entropy, compute_kl_divergence, compute_wasserstein_distance, compute_mutual_information, to_probability_distribution
+from information_metrics import compute_entropy, compute_kl_divergence, compute_wasserstein_distance, compute_mutual_information, to_probability_distribution, compute_self_correlation_score
 
 class TestInformationTheory(unittest.TestCase):
 
@@ -72,6 +72,75 @@ class TestInformationTheory(unittest.TestCase):
         # Assert
         self.assertEqual(entropy_empty, 0.0, "An empty vector should have zero entropy.")
         self.assertEqual(entropy_zero, 0.0, "A zero vector should have zero entropy.")
+
+class TestSelfCorrelationScore(unittest.TestCase):
+
+    def test_perfectly_correlated_vector(self):
+        """
+        Tests a vector where the second half is identical to the first half.
+        """
+        # Arrange
+        vec = [1, 2, 3, 1, 2, 3]
+        # Act
+        score = compute_self_correlation_score(vec)
+        # Assert
+        self.assertAlmostEqual(score, 1.0, places=4)
+
+    def test_perfectly_anti_correlated_vector(self):
+        """
+        Tests a vector where the second half is the inverse of the first half.
+        """
+        # Arrange
+        vec = [1, 2, 3, -1, -2, -3]
+        # Act
+        score = compute_self_correlation_score(vec)
+        # Assert
+        self.assertAlmostEqual(score, -1.0, places=4)
+
+    def test_uncorrelated_vector(self):
+        """
+        Tests a vector with no clear correlation between halves.
+        """
+        # Arrange
+        vec = [1, 5, 2, 8, 3, 7] # No obvious pattern
+        # Act
+        score = compute_self_correlation_score(vec)
+        # Assert
+        # The exact value is not critical, but it should not be close to 1 or -1.
+        self.assertLess(abs(score), 0.9)
+
+    def test_odd_length_vector(self):
+        """
+        Tests that an odd-length vector is handled correctly (middle element ignored).
+        """
+        # Arrange
+        vec = [1, 2, 3, 99, 1, 2, 3] # Middle element 99 should be ignored
+        # Act
+        score = compute_self_correlation_score(vec)
+        # Assert
+        self.assertAlmostEqual(score, 1.0, places=4)
+
+    def test_zero_variance_vector(self):
+        """
+        Tests a vector where one half has zero variance.
+        """
+        # Arrange
+        vec = [1, 2, 3, 5, 5, 5]
+        # Act
+        score = compute_self_correlation_score(vec)
+        # Assert
+        self.assertEqual(score, 0.0)
+
+    def test_short_vector(self):
+        """
+        Tests that a vector with less than 2 elements returns 0.
+        """
+        # Arrange
+        vec = [1]
+        # Act
+        score = compute_self_correlation_score(vec)
+        # Assert
+        self.assertEqual(score, 0.0)
 
 class TestKLDivergence(unittest.TestCase):
 

--- a/tests/test_information_theory.py
+++ b/tests/test_information_theory.py
@@ -102,12 +102,12 @@ class TestSelfCorrelationScore(unittest.TestCase):
         Tests a vector with no clear correlation between halves.
         """
         # Arrange
-        vec = [1, 5, 2, 8, 3, 7] # No obvious pattern
+        vec = [1, 2, 3, 5, 1, 8] # A vector with low correlation between halves
         # Act
         score = compute_self_correlation_score(vec)
         # Assert
         # The exact value is not critical, but it should not be close to 1 or -1.
-        self.assertLess(abs(score), 0.9)
+        self.assertLess(abs(score), 0.5) # Expecting a score around 0.427
 
     def test_odd_length_vector(self):
         """


### PR DESCRIPTION
- `src/information_metrics.py`に`compute_self_correlation_score`関数を追加。
- `src/sigma_sense.py`の`process_experience`メソッドにスコア計算を統合。
- `tests/test_information_theory.py`に`TestSelfCorrelationScore`テストクラスを追加。

Closes #79