### PR TITLE
fix: SigmaSense実行時の各種エラーを修正 (close #64)

### DIFF
--- a/scripts/download_models.py
+++ b/scripts/download_models.py
@@ -11,7 +11,7 @@ os.makedirs(model_dir, exist_ok=True)
 print("--- Downloading TFLite models ---")
 
 # EfficientNet-Lite0
-efficientnet_url = "https://tfhub.dev/tensorflow/efficientnet/lite0/classification/2?tf-hub-format=tflite"
+efficientnet_url = "https://storage.googleapis.com/download.tensorflow.org/models/tflite/task_library/image_classification/lite-model_efficientnet_lite0_int8_1.tflite"
 efficientnet_path = os.path.join(model_dir, "efficientnet_lite0.tflite")
 if not os.path.exists(efficientnet_path):
     print(f"Downloading EfficientNet-Lite0 to {efficientnet_path}...")
@@ -67,7 +67,7 @@ else:
 resnet_path = os.path.join(model_dir, "resnet_v2_50_saved_model")
 if not os.path.exists(resnet_path):
     print("Downloading and saving ResNet V2 50 model...")
-    resnet_url = "https://www.kaggle.com/models/google/resnet-v2/TensorFlow2/50-classification/2"
+    resnet_url = "https://tfhub.dev/google/imagenet/resnet_v2_50/classification/5"
     try:
         resnet_model = hub.KerasLayer(resnet_url)
         tf.saved_model.save(resnet_model, resnet_path)

--- a/sigma_image_engines/engine_mobilenet.py
+++ b/sigma_image_engines/engine_mobilenet.py
@@ -43,8 +43,8 @@ class MobileNetV1Engine:
             img = image_path_or_obj.convert('RGB')
 
         img = img.resize((self.input_width, self.input_height))
-        # Quantized model expects uint8 input, not normalized float
-        input_data = np.array(img, dtype=np.uint8)
+        # The model expects float32 input, normalized to [0, 1]
+        input_data = np.array(img, dtype=np.float32) / 255.0
         input_data = np.expand_dims(input_data, axis=0)
         return input_data
 

--- a/src/build_database.py
+++ b/src/build_database.py
@@ -78,7 +78,14 @@ def build_database(img_dir, db_path, dimension_config_path):
 
     # 最新の次元生成器と次元定義ローダーを初期化
     dim_generator = DimensionGenerator()
-    dim_loader = DimensionLoader() # 引数なしで初期化し、デフォルトの全次元ファイルを読み込む
+    
+    # dimension_config_path を使ってDimensionLoaderを初期化
+    if dimension_config_path:
+        print(f"   指定された次元ファイルを使用: {dimension_config_path}")
+        dim_loader = DimensionLoader(paths=[dimension_config_path])
+    else:
+        print("   デフォルトの全次元ファイルを使用します。")
+        dim_loader = DimensionLoader() # 指定がない場合はデフォルト
 
     database = []
     if not os.path.isdir(img_dir):
@@ -133,8 +140,8 @@ if __name__ == "__main__":
                         help="Directory containing images to process.")
     parser.add_argument("--db_path", type=str, default="config/sigma_product_database_stabilized.json",
                         help="Path to the output SigmaSense product database JSON file.")
-    parser.add_argument("--dimension_config", type=str, default="config/vector_dimensions_mobile.yaml",
-                        help="Path to the dimension configuration file (YAML or JSON).")
+    parser.add_argument("--dimension_config", type=str, default=None,
+                        help="Path to a specific dimension configuration file (YAML or JSON). If not provided, all default dimension files will be used.")
     
     args = parser.parse_args()
     build_database(args.img_dir, args.db_path, args.dimension_config)

--- a/tests/test_sheaf_axioms.py
+++ b/tests/test_sheaf_axioms.py
@@ -6,6 +6,8 @@ import sys
 import shutil
 import cv2 # Import cv2
 from unittest.mock import MagicMock
+import json
+import yaml
 
 # --- Mock modules to bypass heavy dependencies ---
 sys.modules['spacy'] = MagicMock()
@@ -19,6 +21,10 @@ from src.sigma_sense import SigmaSense
 from src.dimension_loader import DimensionLoader
 from src.sigma_database_loader import load_sigma_database
 from src.build_database import build_database
+
+import yaml
+
+# ... (imports) ...
 
 class TestSheafAxiomsSimplified(unittest.TestCase):
 
@@ -44,11 +50,33 @@ class TestSheafAxiomsSimplified(unittest.TestCase):
         img_blue_bgr = cv2.cvtColor(img_blue_np, cv2.COLOR_RGB2BGR)
         cv2.imwrite(cls.blue_image_path, img_blue_bgr)
         
-        # 2. Build a database from these images
-        build_database(db_path=cls.db_path, img_dir=cls.temp_dir, dimension_config_path="config/vector_dimensions_mobile.yaml")
+        # 2. Build a database from these images using merged dimension files
+        project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        dimension_files = [
+            "config/vector_dimensions_mobile.yaml",
+            "config/vector_dimensions_custom_ai.json"
+        ]
+        config_paths = [os.path.join(project_root, path) for path in dimension_files]
+
+        all_dims = []
+        for path in config_paths:
+            if not os.path.exists(path):
+                print(f"Warning: Test dimension file not found: {path}")
+                continue
+            with open(path, 'r', encoding='utf-8') as f:
+                if path.endswith('.json'):
+                    all_dims.extend(json.load(f))
+                elif path.endswith(('.yaml', '.yml')):
+                    all_dims.extend(yaml.safe_load(f))
+        
+        cls.merged_config_path = os.path.join(cls.temp_dir, 'merged_dimensions.json')
+        with open(cls.merged_config_path, 'w', encoding='utf-8') as f:
+            json.dump(all_dims, f)
+
+        build_database(db_path=cls.db_path, img_dir=cls.temp_dir, dimension_config_path=cls.merged_config_path)
 
         # 3. Load the database and instantiate SigmaSense
-        cls.loader = DimensionLoader()
+        cls.loader = DimensionLoader(paths=[cls.merged_config_path])
         database, ids, vectors, _ = load_sigma_database(cls.db_path)
         cls.sigma = SigmaSense(database, ids, vectors, [], dimension_loader=cls.loader)
         cls.ids = ids


### PR DESCRIPTION
issue #64 に対応しました。

### 概要
SigmaSenseの実行時に発生していた、以下の主要なエラーを修正しました。
- 次元不一致による `ValueError`
- モデルロードエラー (`EfficientNet-Lite0`, `ResNet V2 50`)
- `MobileNetV1` 推論時の型不一致

### 主な変更内容
- **`src/build_database.py`**:
  - データベース構築スクリプトが、コマンドラインから次元定義ファイルを指定する引数を正しく使用するように修正しました。これにより、データベースと実行時で次元数が一致し、`ValueError` が解消されます。
- **`scripts/download_models.py`**:
  - `EfficientNet-Lite0` と `ResNet V2 50` のダウンロード元を、リダイレクトの問題が発生しない、より安定した公式URLに変更しました。
- **`sigma_image_engines/engine_mobilenet.py`**:
  - MobileNetV1で推論を行う際、画像データをモデルが期待する `FLOAT32` 型に正しく変換するように前処理を修正しました。

これにより、システムの安定性が向上し、基本的な実行時エラーが解消されます。ご確認のほど、よろしくお願いいたします。