### PR TITLE
fix(cli): 複数のスクリプトにおけるファイルパスと引数の問題を修正

### DIFF
--- a/scripts/run_sigma.py
+++ b/scripts/run_sigma.py
@@ -76,7 +76,7 @@ def main():
     parser.add_argument(
         '--db_path', 
         type=str, 
-        default=os.path.join(project_root, "config", "sigma_product_database_custom_ai_generated.json"),
+        default=os.path.join(project_root, "config", "sigma_product_database_stabilized.json"),
         help='Path to the Sigma product database JSON file.'
     )
     parser.add_argument(

--- a/scripts/run_terrier_comparison.py
+++ b/scripts/run_terrier_comparison.py
@@ -4,6 +4,8 @@ import os
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from src.terrier_vector_generator import generate_terrier_vector
 
+import argparse
+
 def cosine_similarity(v1, v2):
     if not isinstance(v1, np.ndarray):
         v1 = np.array(v1)
@@ -19,10 +21,7 @@ def cosine_similarity(v1, v2):
         
     return dot_product / (norm_v1 * norm_v2)
 
-def main():
-    img1_path = "sigma_images/dog_01.jpg"
-    img2_path = "sigma_images/dog_02.jpg"
-
+def main(img1_path, img2_path):
     vector1 = generate_terrier_vector(img1_path)
     vector2 = generate_terrier_vector(img2_path)
 
@@ -45,4 +44,8 @@ def main():
         print("判定: これらは異なる犬種である可能性が高いです。")
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser(description='2枚のテリア犬の画像の類似度を比較します。')
+    parser.add_argument('image1_path', type=str, help='1枚目の画像ファイルのパス')
+    parser.add_argument('image2_path', type=str, help='2枚目の画像ファイルのパス')
+    args = parser.parse_args()
+    main(args.image1_path, args.image2_path)

--- a/src/semantic_axis_aggregator.py
+++ b/src/semantic_axis_aggregator.py
@@ -1,7 +1,7 @@
 import os
 import json
 import numpy as np
-from dimension_loader import DimensionLoader
+from src.dimension_loader import DimensionLoader
 
 def aggregate_semantic_axes(log_dir=None):
     """


### PR DESCRIPTION
複数の実行スクリプトに存在した、モジュールインポートエラー、ハードコーディングされたファイルパス、ドキュメントとの不整合を修正しました。

- `src/semantic_axis_aggregator.py`:
  - `dimension_loader` のインポートパスを修正し、`ModuleNotFoundError` を解決。 (Closes #186)
- `scripts/run_terrier_comparison.py`:
  - ハードコーディングされていた画像パスをコマンドライン引数に変更し、柔軟性を向上。 (Closes #184)
- `scripts/run_sigma.py`:
  - デフォルトのデータベースパスを `README.md` の記述と一致させ、`FileNotFoundError` を解消。 (Closes #183)