### PR TITLE
fix(ci): numpyのバージョンをPython 3.9互換に修正

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # It is recommended to use a Python version 3.9 or higher.
 
 # Core scientific libraries
-numpy==2.3.3
+numpy==1.26.4
 scikit-learn==1.7.2
 scipy==1.16.2
 


### PR DESCRIPTION
GitHub ActionsのCIでnumpyのバージョンがPython 3.9と互換性がなく、依存関係のインストールに失敗していた問題を修正しました。

- `requirements.txt` の `numpy` のバージョンを `2.3.3` から `1.26.4` にダウングレード。

これにより、CI環境での依存関係のインストールが正常に完了し、ワークフローが続行できるようになります。