### PR TITLE
fix(ci): scikit-learnとscipyのバージョンをPython 3.9互換に修正

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@
 
 # Core scientific libraries
 numpy==1.26.4
-scikit-learn==1.6.1
-scipy==1.16.2
+scikit-learn==1.4.2
+scipy==1.13.1
 
 # Image processing
 opencv-python


### PR DESCRIPTION
GitHub ActionsのCIでscikit-learnとscipyのバージョンがPython 3.9と互換性がなく、依存関係のインストールに失敗していた問題を修正しました。

- `requirements.txt` の `scikit-learn` のバージョンを `1.6.1` から `1.4.2` にダウングレード。
- `requirements.txt` の `scipy` のバージョンを `1.16.2` から `1.13.1` にダウングレード。

これにより、CI環境での依存関係のインストールが正常に完了し、ワークフローが続行できるようになります。