### PR TITLE
fix(ci): scikit-imageのバージョンをPython 3.9互換に修正

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ scipy==1.13.1
 # Image processing
 opencv-python
 Pillow==11.3.0
-scikit-image==0.25.2
+scikit-image==0.24.0
 
 # AI/ML
 tensorflow==2.20.0


### PR DESCRIPTION
WIP