### PR TITLE
fix(workflow): Correct argument name for generate_number_image.py

### DIFF
--- a/.github/workflows/manual-workflows.yml
+++ b/.github/workflows/manual-workflows.yml
@@ -72,7 +72,7 @@ jobs:
     - name: Run narrative analysis script
       run: python scripts/run_narrative_analysis.py
     - name: Generate number image
-      run: python src/generate_number_image.py --number 123 --save_path generated_number.png
+      run: python src/generate_number_image.py --number 123 --output_path generated_number.png
     - name: Generate AI image vectors
       run: python src/generate_ai_image_vectors.py --image_path sigma_images/circle_center.jpg
     - name: Generate AI dimensions


### PR DESCRIPTION
Fixes #212

This PR corrects the argument name from `--save_path` to `--output_path` when calling `generate_number_image.py` in `.github/workflows/manual-workflows.yml` to resolve the unrecognized argument error.