### PR TITLE
fix(workflow): Add missing image paths to run_terrier_comparison.py call

### DIFF
--- a/.github/workflows/run-scripts.yml
+++ b/.github/workflows/run-scripts.yml
@@ -47,6 +47,6 @@ jobs:
     - name: Generate AI dimensions
       run: python src/generate_ai_dimensions.py
     - name: Run terrier comparison script
-      run: python scripts/run_terrier_comparison.py
+      run: python scripts/run_terrier_comparison.py sigma_images/circle_center.jpg sigma_images/square_left.jpg
     - name: Run psyche simulation script
       run: python scripts/run_psyche_simulation.py


### PR DESCRIPTION
Fixes #218

This PR addresses issue #218 by adding the required `image1_path` and `image2_path` arguments to the `run_terrier_comparison.py` call in `.github/workflows/run-scripts.yml`.