### PR TITLE
fix(syntax): Correct nested f-string quoting in toyokawa_model.py

### DIFF
--- a/src/toyokawa_model.py
+++ b/src/toyokawa_model.py
@@ -35,7 +35,7 @@ class ToyokawaModel:
             }
 
         print("Model weights (α, β, γ) have been set.")
-        print(f"  - Alpha (αᵢ): {self.weights.get('alpha', {}).get(f"E_{self.agents[0]}", 0):.2f} for each agent")
+        print(f'  - Alpha (αᵢ): {self.weights.get("alpha", {}).get(f"E_{self.agents[0]}", 0):.2f} for each agent')
         print(f"  - Beta (β): {self.weights.get("beta", 0)}")
         print(f"  - Gamma (γ): {self.weights.get("gamma", 0)}")
 


### PR DESCRIPTION
Fixes #223. Corrects nested f-string quoting in src/toyokawa_model.py.