### PR TITLE
fix(script): Correct gemini_client import path in run_online_integration.py

### DIFF
--- a/scripts/run_online_integration.py
+++ b/scripts/run_online_integration.py
@@ -2,7 +2,7 @@ import json
 import os
 import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
-from gemini_client import GeminiClient # オリエン大賢者をインポート
+from src.gemini_client import GeminiClient # オリエン大賢者をインポート
 
 def run_integration_process():
     """Reads the offline log, has Orien review it, and prepares for permanentization."""


### PR DESCRIPTION
Fixes #237. Corrects the import path for gemini_client in scripts/run_online_integration.py.