### PR TITLE
fix(script): Explicitly add src/ to sys.path in run_online_integration.py

### DIFF
--- a/scripts/run_online_integration.py
+++ b/scripts/run_online_integration.py
@@ -2,6 +2,7 @@ import json
 import os
 import sys
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
 from src.gemini_client import GeminiClient # オリエン大賢者をインポート
 
 def run_integration_process():


### PR DESCRIPTION
Fixes #241. Explicitly adds the src/ directory to sys.path in scripts/run_online_integration.py to resolve ModuleNotFoundError for gemini_client.