### PR TITLE
fix(workflow): Add Rust installation for SudachiPy in manual-workflows.yml

### DIFF
--- a/.github/workflows/manual-workflows.yml
+++ b/.github/workflows/manual-workflows.yml
@@ -43,6 +43,10 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: '3.11'
+    - name: Install Rust (for SudachiPy)
+      run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        echo "$HOME/.cargo/bin" >> $GITHUB_PATH
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
Fixes #243. Adds a step to install Rust in manual-workflows.yml to resolve the SudachiPy build error during dependency installation.